### PR TITLE
fix access to array element by using the one that was checked for

### DIFF
--- a/src/Clue/PharComposer/Bundler/Explicit.php
+++ b/src/Clue/PharComposer/Bundler/Explicit.php
@@ -55,7 +55,7 @@ class Explicit extends Base
             }
 
             if (isset($autoload['files'])) {
-                foreach($autoload['classmap'] as $path) {
+                foreach($autoload['files'] as $path) {
                     $this->addFile($this->package->getAbsolutePath($path));
                 }
             }


### PR DESCRIPTION
Just played around with it and tried to get only the minimum file set into my resulting phar, therefore tried to use the `ExplicitBundler` with my dependencies. One of these has files defined, which currently results in a warning when this line is executed:

```
Warning: Invalid argument supplied for foreach() in phar:///path/to/phar-composer.phar/src/Clue/PharComposer/Bundler/Explicit.php on line 58
```
