### PR TITLE
Exclude support, fixes #5

### DIFF
--- a/src/Clue/PharComposer/Bundler/Explicit.php
+++ b/src/Clue/PharComposer/Bundler/Explicit.php
@@ -76,17 +76,19 @@ class Explicit implements BundlerInterface
 
     private function addFile(Bundle $bundle, $file)
     {
-        $this->logger->log('    adding "' . $file . '"');
-        $bundle->addFile($this->package->getAbsolutePath($file));
+        if (!$this->package->isBlacklisted($this->package->getAbsolutePath($file))) {
+            $this->logger->log('    adding "' . $file . '"');
+            $bundle->addFile($this->package->getAbsolutePath($file));
+        }
     }
 
     private function addDir(Bundle $bundle, $dir)
     {
-        $dir = $this->package->getAbsolutePath(rtrim($dir, '/') . '/');
         $this->logger->log('    adding "' . $dir . '"');
+        $dir = $this->package->getAbsolutePath(rtrim($dir, '/') . '/');
         $bundle->addDir(Finder::create()
                               ->files()
-                              //->filter($this->getBlacklistFilter())
+                              ->filter($this->package->getBlacklistFilter())
                               ->ignoreVCS(true)
                               ->in($dir));
     }

--- a/src/Clue/PharComposer/Package.php
+++ b/src/Clue/PharComposer/Package.php
@@ -74,10 +74,23 @@ class Package
 
     public function getBlacklist()
     {
-        return array(
-            $this->getAbsolutePath('composer.phar'),
-            $this->getAbsolutePath('phar-composer.phar')
-        );
+        $blacklist   = $this->getAdditionalExcludes();
+        $blacklist[] = 'composer.phar';
+        $blacklist[] = 'phar-composer.phar';
+        return array_map(array($this, 'getAbsolutePath'), $blacklist);
+    }
+
+    private function getAdditionalExcludes()
+    {
+        if (isset($this->package['extra']['phar']['excludes'])) {
+            if (!is_array($this->package['extra']['phar']['excludes'])) {
+                return array($this->package['extra']['phar']['excludes']);
+            }
+
+            return $this->package['extra']['phar']['excludes'];
+        }
+
+        return array();
     }
 
     /**

--- a/src/Clue/PharComposer/Package.php
+++ b/src/Clue/PharComposer/Package.php
@@ -10,6 +10,8 @@ use Clue\PharComposer\Package\Autoload;
 
 class Package
 {
+    private $blacklist;
+
     public function __construct(array $package, $directory)
     {
         $this->package = $package;
@@ -72,12 +74,37 @@ class Package
         return $bins;
     }
 
+    /**
+     * checks if given resource is blacklisted which means it should not be added to the target phar
+     *
+     * @param   string  $resource
+     * @return  bool
+     */
+    public function isBlacklisted($resource)
+    {
+        if (in_array($resource, $this->getBlacklist())) {
+            return true;
+        }
+
+        foreach ($this->getBlacklist() as $path) {
+            if (substr($resource, 0, strlen($path)) === $path) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public function getBlacklist()
     {
-        $blacklist   = $this->getAdditionalExcludes();
-        $blacklist[] = 'composer.phar';
-        $blacklist[] = 'phar-composer.phar';
-        return array_map(array($this, 'getAbsolutePath'), $blacklist);
+        if (null === $this->blacklist) {
+            $blacklist   = $this->getAdditionalExcludes();
+            $blacklist[] = 'composer.phar';
+            $blacklist[] = 'phar-composer.phar';
+            $this->blacklist = array_map(array($this, 'getAbsolutePath'), $blacklist);
+        }
+
+        return $this->blacklist;
     }
 
     private function getAdditionalExcludes()

--- a/src/Clue/PharComposer/Package.php
+++ b/src/Clue/PharComposer/Package.php
@@ -82,12 +82,12 @@ class Package
 
     private function getAdditionalExcludes()
     {
-        if (isset($this->package['extra']['phar']['excludes'])) {
-            if (!is_array($this->package['extra']['phar']['excludes'])) {
-                return array($this->package['extra']['phar']['excludes']);
+        if (isset($this->package['extra']['phar']['exclude'])) {
+            if (!is_array($this->package['extra']['phar']['exclude'])) {
+                return array($this->package['extra']['phar']['exclude']);
             }
 
-            return $this->package['extra']['phar']['excludes'];
+            return $this->package['extra']['phar']['exclude'];
         }
 
         return array();

--- a/tests/ExplicitBundlerTest.php
+++ b/tests/ExplicitBundlerTest.php
@@ -86,8 +86,8 @@ class ExplicitBundlerTest extends TestCase
      */
     public function addsAllPathesDefinedByPsr0WithSeveralPathes()
     {
-        $this->package = new Package(array('autoload' => array('psr-0' => array('Clue' => array('src/',
-                                                                                                'src/'
+        $this->package = new Package(array('autoload' => array('psr-0' => array('Clue' => array('src',
+                                                                                                'src'
                                                                                           )
                                                                           )
                                                          )
@@ -96,8 +96,46 @@ class ExplicitBundlerTest extends TestCase
                          );
         $this->explicitBundler = new ExplicitBundler($this->package, $this->createMock('Clue\PharComposer\Logger'));
         $bundle = $this->explicitBundler->bundle();
-        $this->assertTrue($bundle->contains($this->path . '/src'),
-                          'Failed asserting that ' . $this->path . '/src' . ' is contained in bundle'
+        $this->assertTrue($bundle->contains($this->path . '/src/Clue'),
+                          'Failed asserting that ' . $this->path . '/src/Clue' . ' is contained in bundle'
         );
+    }
+
+    /**
+     * @test
+     * @group exclude
+     */
+    public function doesNotAddBlacklistedFiles()
+    {
+        $this->package = new Package(array('autoload' => array('files'    => array('foo.php'),
+                                                               'classmap' => array('src/Example/SomeClass.php'),
+                                                               'psr-0'    => array('Clue' => 'src')
+                                                         ),
+                                           'extra'    => array('phar'     => array('exclude' => array('foo.php', 'src')))
+                                     ),
+                                     $this->path . '/'
+                         );
+        $this->explicitBundler = new ExplicitBundler($this->package, $this->createMock('Clue\PharComposer\Logger'));
+        $bundle = $this->explicitBundler->bundle();
+        $this->assertFalse($bundle->contains($this->path . '/foo.php'));
+    }
+
+    /**
+     * @test
+     * @group exclude
+     */
+    public function doesNotAddBlacklistedFilesFromClassmap()
+    {
+        $this->package = new Package(array('autoload' => array('files'    => array('foo.php'),
+                                                               'classmap' => array('src/Example/SomeClass.php'),
+                                                               'psr-0'    => array('Clue' => 'src')
+                                                         ),
+                                           'extra'    => array('phar'     => array('exclude' => array('foo.php', 'src')))
+                                     ),
+                                     $this->path . '/'
+                         );
+        $this->explicitBundler = new ExplicitBundler($this->package, $this->createMock('Clue\PharComposer\Logger'));
+        $bundle = $this->explicitBundler->bundle();
+        $this->assertFalse($bundle->contains($this->path . '/src/Example/SomeClass.php'));
     }
 }

--- a/tests/PackageTest.php
+++ b/tests/PackageTest.php
@@ -112,7 +112,7 @@ class PackageTest extends TestCase
         $package = new Package(array(
             'extra' => array(
                 'phar' => array(
-                    'excludes' => 'phpunit.xml.dist'
+                    'exclude' => 'phpunit.xml.dist'
                 )
             )
         ), 'dir/');
@@ -129,7 +129,7 @@ class PackageTest extends TestCase
         $package = new Package(array(
             'extra' => array(
                 'phar' => array(
-                    'excludes' => array('phpunit.xml.dist', '.travis.yml')
+                    'exclude' => array('phpunit.xml.dist', '.travis.yml')
                 )
             )
         ), 'dir/');

--- a/tests/PackageTest.php
+++ b/tests/PackageTest.php
@@ -96,4 +96,14 @@ class PackageTest extends TestCase
                                 $package->getBundler($mockLogger)
         );
     }
+
+    public function testBlackListContainsComposerAndPharComposerByDefault()
+    {
+        $package = new Package(array(), 'dir/');
+        $this->assertEquals(array('dir/composer.phar',
+                                  'dir/phar-composer.phar'
+                            ),
+                            $package->getBlacklist()
+        );
+    }
 }

--- a/tests/PackageTest.php
+++ b/tests/PackageTest.php
@@ -97,10 +97,45 @@ class PackageTest extends TestCase
         );
     }
 
-    public function testBlackListContainsComposerAndPharComposerByDefault()
+    public function testBlacklistContainsComposerAndPharComposerByDefault()
     {
         $package = new Package(array(), 'dir/');
         $this->assertEquals(array('dir/composer.phar',
+                                  'dir/phar-composer.phar'
+                            ),
+                            $package->getBlacklist()
+        );
+    }
+
+    public function testBlacklistContainsAdditionalExcludeFromConfig()
+    {
+        $package = new Package(array(
+            'extra' => array(
+                'phar' => array(
+                    'excludes' => 'phpunit.xml.dist'
+                )
+            )
+        ), 'dir/');
+        $this->assertEquals(array('dir/phpunit.xml.dist',
+                                  'dir/composer.phar',
+                                  'dir/phar-composer.phar'
+                            ),
+                            $package->getBlacklist()
+        );
+    }
+
+    public function testBlacklistContainsAdditionalExcludesFromConfig()
+    {
+        $package = new Package(array(
+            'extra' => array(
+                'phar' => array(
+                    'excludes' => array('phpunit.xml.dist', '.travis.yml')
+                )
+            )
+        ), 'dir/');
+        $this->assertEquals(array('dir/phpunit.xml.dist',
+                                  'dir/.travis.yml',
+                                  'dir/composer.phar',
                                   'dir/phar-composer.phar'
                             ),
                             $package->getBlacklist()

--- a/tests/PackageTest.php
+++ b/tests/PackageTest.php
@@ -97,7 +97,11 @@ class PackageTest extends TestCase
         );
     }
 
-    public function testBlacklistContainsComposerAndPharComposerByDefault()
+    /**
+     * @test
+     * @group exclude
+     */
+    public function blacklistContainsComposerAndPharComposerByDefault()
     {
         $package = new Package(array(), 'dir/');
         $this->assertEquals(array('dir/composer.phar',
@@ -107,7 +111,11 @@ class PackageTest extends TestCase
         );
     }
 
-    public function testBlacklistContainsAdditionalExcludeFromConfig()
+    /**
+     * @test
+     * @group exclude
+     */
+    public function blacklistContainsAdditionalExcludeFromConfig()
     {
         $package = new Package(array(
             'extra' => array(
@@ -124,7 +132,11 @@ class PackageTest extends TestCase
         );
     }
 
-    public function testBlacklistContainsAdditionalExcludesFromConfig()
+    /**
+     * @test
+     * @group exclude
+     */
+    public function blacklistContainsAdditionalExcludesFromConfig()
     {
         $package = new Package(array(
             'extra' => array(


### PR DESCRIPTION
This PR adds support for excluding files (and directories) as described in #5 and originally implemented in #15.

At the moment I'm unsure if `Package::isBlacklisted()` is implemented correctly to exclude files from being added in the `ExplicitBundler::addFile()` method. It should be possible to exclude directories which then must be respected for the files defined via autoload's `files` and `classmap` definitions. From the code it seems like it's different from the filter defined in `Package::getBlacklistFilter()`, nevertheless I suppose the same functionality is already there, but hidden in how Symfony's `Finder` works.
