### PR TITLE
Support adding clue/phar-composer as a require-dev and running out of vendor/bin

### DIFF
--- a/bin/phar-composer
+++ b/bin/phar-composer
@@ -1,7 +1,12 @@
 #!/usr/bin/env php
 <?php
 
-require __DIR__ . '/../vendor/autoload.php';
+if (file_exists(__DIR__ . '/../vendor/autoload.php'))
+    require     __DIR__ . '/../vendor/autoload.php';
+else if (file_exists(__DIR__ . '/../../../autoload.php'))
+    require          __DIR__ . '/../../../autoload.php';
+else
+    die('dependencies not installed; run: curl -O http://getcomposer.org/composer.phar; php composer.phar install' . PHP_EOL);
 
 $app = new Clue\PharComposer\App();
 $app->run();


### PR DESCRIPTION
From a random project running

```
php composer.phar require --dev clue/phar-composer
php composer.phar update
php composer.phar install
```

allows this

```
./vendor/bin/phar-composer
```

to work using a technique similar to the one used by phpunit.
