### PR TITLE
Actually exclude the vendor dir

### DIFF
--- a/src/Clue/PharComposer/Bundler/Complete.php
+++ b/src/Clue/PharComposer/Bundler/Complete.php
@@ -40,7 +40,7 @@ class Complete implements BundlerInterface
             ->files()
             ->ignoreVCS(true)
             ->filter($this->package->getBlacklistFilter())
-            ->exclude($this->package->getPathVendor())
+            ->exclude($this->package->getPathVendorRelative())
             ->in($this->package->getDirectory());
         $this->logger->log('    Adding whole project directory "' . $this->package->getDirectory() . '"');
         return $bundle->addDir($iterator);

--- a/src/Clue/PharComposer/Package.php
+++ b/src/Clue/PharComposer/Package.php
@@ -21,14 +21,18 @@ class Package
         return isset($this->package['name']) ? $this->package['name'] : 'unknown';
     }
 
-    public function getPathVendor()
+    public function getPathVendorRelative()
     {
         $vendor = 'vendor';
         if (isset($this->package['config']['vendor-dir'])) {
             $vendor = $this->package['config']['vendor-dir'];
         }
+        return $vendor;
+    }
 
-        return $this->getAbsolutePath($vendor . '/');
+    public function getPathVendor()
+    {
+        return $this->getAbsolutePath($this->getPathVendorRelative() . '/');
     }
 
     public function getDirectory()


### PR DESCRIPTION
This avoids including the entire vendor directory twice which greatly speeds up phar generation.