### PR TITLE
Use composer.lock required packages instead of vendor/installed.json

### DIFF
--- a/src/Clue/PharComposer/PharComposer.php
+++ b/src/Clue/PharComposer/PharComposer.php
@@ -136,24 +136,8 @@ class PharComposer
           }
         }
         else {
-          throw new RuntimeException('You should composer install before doing anything my friend');
+          //throw new RuntimeException('You should composer install before doing anything my friend');
         }
-        /*
-        // load all installed packages (use installed.json which also includes version instead of composer.lock)
-        if (is_file($pathVendor . 'composer/installed.json')) {
-            // file does not exist if there's nothing to be installed
-            $installed = $this->loadJson($pathVendor . 'composer/installed.json');
-
-            foreach ($installed as $package) {
-                $dir = $package['name'] . '/';
-                if (isset($package['target-dir'])) {
-                    $dir .= trim($package['target-dir'], '/') . '/';
-                }
-
-                $dir = $pathVendor . $dir;
-                $packages []= new Package($package, $dir);
-            }
-        }*/
 
         return $packages;
     }

--- a/src/Clue/PharComposer/PharComposer.php
+++ b/src/Clue/PharComposer/PharComposer.php
@@ -121,7 +121,24 @@ class PharComposer
         $packages = array();
 
         $pathVendor = $this->getPathVendor();
+        $path=$this->getBase();
+        if(is_file($path.'composer.lock')){
+          $composer=$this->loadJson($path.'composer.lock');
+          $installed=$composer["packages"];
+          foreach ($installed as $package) {
+              $dir = $package['name'] . '/';
+              if (isset($package['target-dir'])) {
+                  $dir .= trim($package['target-dir'], '/') . '/';
+              }
 
+              $dir = $pathVendor . $dir;
+              $packages []= new Package($package, $dir);
+          }
+        }
+        else {
+          throw new RuntimeException('You should composer install before doing anything my friend');
+        }
+        /*
         // load all installed packages (use installed.json which also includes version instead of composer.lock)
         if (is_file($pathVendor . 'composer/installed.json')) {
             // file does not exist if there's nothing to be installed
@@ -136,7 +153,7 @@ class PharComposer
                 $dir = $pathVendor . $dir;
                 $packages []= new Package($package, $dir);
             }
-        }
+        }*/
 
         return $packages;
     }


### PR DESCRIPTION
Using composer.lock to laod the  packages allows to not require dev dependencies (PHPUnit is big as dep so don't put it if we don't need it in the actual builded phar)
