### PR TITLE
Fix error reporting for invalid project paths

### DIFF
--- a/src/Clue/PharComposer/Packager.php
+++ b/src/Clue/PharComposer/Packager.php
@@ -48,6 +48,13 @@ class Packager
         $this->output = $fn;
     }
 
+    /**
+     * ensure writing phar files is enabled or respawn with PHP setting which allows writing
+     *
+     * @param int $wait
+     * @return void
+     * @uses assertWritable()
+     */
     public function coerceWritable($wait = 1)
     {
         try {
@@ -72,6 +79,11 @@ class Packager
         }
     }
 
+    /**
+     * ensure writing phar files is enabled or throw an exception
+     *
+     * @throws UnexpectedValueException
+     */
     public function assertWritable()
     {
         if (ini_get('phar.readonly') === '1') {
@@ -85,8 +97,6 @@ class Packager
             // TODO: should be the other way around
             $path .= ':' . $version;
         }
-
-        $this->assertWritable();
 
         $step = 1;
         $steps = 1;

--- a/src/Clue/PharComposer/Packager.php
+++ b/src/Clue/PharComposer/Packager.php
@@ -189,9 +189,8 @@ class Packager
         $pharer->setStep($step);
 
         $pathVendor = $pharer->getPathVendor();
-        if (!is_dir($pathVendor)) {
-            $this->log('<error>Project is not installed via composer. Run "composer install" manually</error>');
-            return;
+        if (!is_dir($pathVendor)) {        
+            throw new RuntimeException('Project is not installed via composer. Run "composer install" manually');
         }
 
         return $pharer;

--- a/src/Clue/PharComposer/Packager.php
+++ b/src/Clue/PharComposer/Packager.php
@@ -6,6 +6,7 @@ use Symfony\Component\Process\Process;
 use Symfony\Component\Process\ExecutableFinder;
 use UnexpectedValueException;
 use InvalidArgumentException;
+use RuntimeException;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Packager
@@ -189,7 +190,7 @@ class Packager
         $pharer->setStep($step);
 
         $pathVendor = $pharer->getPathVendor();
-        if (!is_dir($pathVendor)) {        
+        if (!is_dir($pathVendor)) {
             throw new RuntimeException('Project is not installed via composer. Run "composer install" manually');
         }
 

--- a/tests/PackagerTest.php
+++ b/tests/PackagerTest.php
@@ -1,8 +1,16 @@
 <?php
 
 use Clue\PharComposer\Packager;
+
 class PackagerTest extends TestCase
 {
+    private $packager;
+
+    public function setUp()
+    {
+        $this->packager = new Packager();
+    }
+
     /**
      *
      * @param string $expectedOutput
@@ -11,11 +19,9 @@ class PackagerTest extends TestCase
      */
     public function testExec($expectedOutput, $command)
     {
-        $packager = new Packager();
-
         $this->expectOutputString($expectedOutput);
 
-        $packager->exec($command);
+        $this->packager->exec($command);
     }
 
     public function provideExecCommands()
@@ -25,5 +31,32 @@ class PackagerTest extends TestCase
             array("\n    error\n", 'echo error >&2'),
             array("\n    mixed\n    errors\n", 'echo mixed && echo errors >&1'),
         );
+    }
+
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage not installed
+     */
+    public function testEmptyNotInstalled()
+    {
+        $this->packager->getPharer(__DIR__ . '/fixtures/01-empty');
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage not a readable file
+     */
+    public function testNoComposer()
+    {
+        $this->packager->getPharer(__DIR__ . '/fixtures/02-no-composer');
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage not a readable file
+     */
+    public function testNoComposerMissing()
+    {
+        $this->packager->getPharer(__DIR__ . '/fixtures/02-no-composer/composer.json');
     }
 }

--- a/tests/fixtures/01-empty/composer.json
+++ b/tests/fixtures/01-empty/composer.json
@@ -1,0 +1,3 @@
+{
+    "name": "vendor/empty"
+}

--- a/tests/fixtures/02-no-composer/README.md
+++ b/tests/fixtures/02-no-composer/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+Not a valid project directory (does not contain a `composer.json` file).


### PR DESCRIPTION
Build on top of #42, closes #42.

```
$ php bin/phar-composer build invalid/

  [InvalidArgumentException]
  The given path "invalid/composer.json" is not a readable file

build [path] [target]

```