### PR TITLE
Ignore build errors on PHP 7 and HHVM until they're sufficiently stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,12 @@ php:
   - 5.3
   - 5.6
   - 7
+  - hhvm
+
+matrix:
+  allow_failures:
+    - php: 7
+    - php: hhvm
 
 install:
   - composer install --prefer-source --no-interaction


### PR DESCRIPTION
Looks like this has stopped working earlier today. Several people have reported similar issues, so I suppose this is due to a (temporary?) error in TravisCI?

Refs #54 and #49.