### PR TITLE
Switch to error message instead of info

### DIFF
--- a/src/Clue/PharComposer/Phar/Packager.php
+++ b/src/Clue/PharComposer/Phar/Packager.php
@@ -66,7 +66,7 @@ class Packager
                 return;
             }
 
-            $this->log('<info>' . $e->getMessage() . ', trying to re-spawn with correct config</info>');
+            $this->log('<error>' . $e->getMessage() . ', trying to re-spawn with correct config</error>');
             if ($wait) {
                 sleep($wait);
             }


### PR DESCRIPTION
Just a little contribution but I was pretty confused when I saw the green message saying « there is an error ».

So here is a fix to write it properly.
