### PR TITLE
Update all dependencies and improve forward compatibility with upcoming symfony/console v5 through legacy v2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ matrix:
   include:
     - php: 5.3
       dist: precise
+    - php: 7.3
+      install: []
+      script: composer install --dry-run --working-dir=tests/install-as-dep
   allow_failures:
     - php: hhvm
 

--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,11 @@
         }
     ],
     "require": {
-        "herrera-io/box": "~1.5",
-        "symfony/console": "~2.1",
-        "symfony/finder": "~2.1",
-        "symfony/process": "~2.1",
-        "knplabs/packagist-api": "~1.0"
+        "herrera-io/box": "^1.5",
+        "knplabs/packagist-api": "^1.0",
+        "symfony/console": "^4.0 || ^3.0 || ^2.5",
+        "symfony/finder": "^4.0 || ^3.0 || ^2.5",
+        "symfony/process": "^4.0 || ^3.0 || ^2.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8"

--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,9 @@
     "require": {
         "herrera-io/box": "^1.5",
         "knplabs/packagist-api": "^1.0",
-        "symfony/console": "^4.0 || ^3.0 || ^2.5",
-        "symfony/finder": "^4.0 || ^3.0 || ^2.5",
-        "symfony/process": "^4.0 || ^3.0 || ^2.5"
+        "symfony/console": "^5.0 || ^4.0 || ^3.0 || ^2.5",
+        "symfony/finder": "^5.0 || ^4.0 || ^3.0 || ^2.5",
+        "symfony/process": "^5.0 || ^4.0 || ^3.0 || ^2.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d1bb9730e0e624e9bf039c54cd8be9c8",
+    "content-hash": "81105e27df07351c5822c7f521bddca0",
     "packages": [
         {
             "name": "doctrine/inflector",

--- a/composer.lock
+++ b/composer.lock
@@ -8,22 +8,30 @@
     "packages": [
         {
             "name": "doctrine/inflector",
-            "version": "v1.0",
+            "version": "v1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/inflector.git",
-                "reference": "54b8333d2a5682afdc690060c1cf384ba9f47f08"
+                "reference": "90b2128806bfde671b6952ab8bea493942c1fdae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/inflector/zipball/54b8333d2a5682afdc690060c1cf384ba9f47f08",
-                "reference": "54b8333d2a5682afdc690060c1cf384ba9f47f08",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/90b2128806bfde671b6952ab8bea493942c1fdae",
+                "reference": "90b2128806bfde671b6952ab8bea493942c1fdae",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.2"
             },
+            "require-dev": {
+                "phpunit/phpunit": "4.*"
+            },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
             "autoload": {
                 "psr-0": {
                     "Doctrine\\Common\\Inflector\\": "lib/"
@@ -35,16 +43,6 @@
             ],
             "authors": [
                 {
-                    "name": "Jonathan Wage",
-                    "email": "jonwage@gmail.com",
-                    "homepage": "http://www.jwage.com/"
-                },
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com",
-                    "homepage": "http://www.instaclick.com"
-                },
-                {
                     "name": "Roman Borschel",
                     "email": "roman@code-factory.org"
                 },
@@ -53,100 +51,93 @@
                     "email": "kontakt@beberlei.de"
                 },
                 {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
                     "name": "Johannes Schmitt",
-                    "email": "schmittjoh@gmail.com",
-                    "homepage": "https://github.com/schmittjoh",
-                    "role": "Developer of wrapped JMSSerializerBundle"
+                    "email": "schmittjoh@gmail.com"
                 }
             ],
             "description": "Common String Manipulations with regard to casing and singular/plural rules.",
             "homepage": "http://www.doctrine-project.org",
             "keywords": [
                 "inflection",
-                "pluarlize",
-                "singuarlize",
+                "pluralize",
+                "singularize",
                 "string"
             ],
-            "time": "2013-01-10T21:49:15+00:00"
+            "time": "2015-11-06T14:35:42+00:00"
         },
         {
-            "name": "guzzle/common",
-            "version": "v3.8.0",
-            "target-dir": "Guzzle/Common",
+            "name": "guzzle/guzzle",
+            "version": "v3.9.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Guzzle3/common.git",
-                "reference": "eb4e34cac1b18583f0ee74bf6a9dda96bd771a1e"
+                "url": "https://github.com/guzzle/guzzle3.git",
+                "reference": "0645b70d953bc1c067bbc8d5bc53194706b628d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Guzzle3/common/zipball/eb4e34cac1b18583f0ee74bf6a9dda96bd771a1e",
-                "reference": "eb4e34cac1b18583f0ee74bf6a9dda96bd771a1e",
+                "url": "https://api.github.com/repos/guzzle/guzzle3/zipball/0645b70d953bc1c067bbc8d5bc53194706b628d9",
+                "reference": "0645b70d953bc1c067bbc8d5bc53194706b628d9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.2",
-                "symfony/event-dispatcher": ">=2.1"
+                "ext-curl": "*",
+                "php": ">=5.3.3",
+                "symfony/event-dispatcher": "~2.1"
             },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.7-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Guzzle\\Common": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Common libraries used by Guzzle",
-            "homepage": "http://guzzlephp.org/",
-            "keywords": [
-                "collection",
-                "common",
-                "event",
-                "exception"
-            ],
-            "abandoned": "guzzle/guzzle",
-            "time": "2013-12-05T23:39:20+00:00"
-        },
-        {
-            "name": "guzzle/http",
-            "version": "v3.8.0",
-            "target-dir": "Guzzle/Http",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Guzzle3/http.git",
-                "reference": "b497e6b6a5a85751ae0c6858d677f7c4857dd171"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Guzzle3/http/zipball/b497e6b6a5a85751ae0c6858d677f7c4857dd171",
-                "reference": "b497e6b6a5a85751ae0c6858d677f7c4857dd171",
-                "shasum": ""
-            },
-            "require": {
+            "replace": {
+                "guzzle/batch": "self.version",
+                "guzzle/cache": "self.version",
                 "guzzle/common": "self.version",
+                "guzzle/http": "self.version",
+                "guzzle/inflection": "self.version",
+                "guzzle/iterator": "self.version",
+                "guzzle/log": "self.version",
                 "guzzle/parser": "self.version",
-                "guzzle/stream": "self.version",
-                "php": ">=5.3.2"
+                "guzzle/plugin": "self.version",
+                "guzzle/plugin-async": "self.version",
+                "guzzle/plugin-backoff": "self.version",
+                "guzzle/plugin-cache": "self.version",
+                "guzzle/plugin-cookie": "self.version",
+                "guzzle/plugin-curlauth": "self.version",
+                "guzzle/plugin-error-response": "self.version",
+                "guzzle/plugin-history": "self.version",
+                "guzzle/plugin-log": "self.version",
+                "guzzle/plugin-md5": "self.version",
+                "guzzle/plugin-mock": "self.version",
+                "guzzle/plugin-oauth": "self.version",
+                "guzzle/service": "self.version",
+                "guzzle/stream": "self.version"
+            },
+            "require-dev": {
+                "doctrine/cache": "~1.3",
+                "monolog/monolog": "~1.0",
+                "phpunit/phpunit": "3.7.*",
+                "psr/log": "~1.0",
+                "symfony/class-loader": "~2.1",
+                "zendframework/zend-cache": "2.*,<2.3",
+                "zendframework/zend-log": "2.*,<2.3"
             },
             "suggest": {
-                "ext-curl": "*"
+                "guzzlehttp/guzzle": "Guzzle 5 has moved to a new package name. The package you have installed, Guzzle 3, is deprecated."
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.7-dev"
+                    "dev-master": "3.9-dev"
                 }
             },
             "autoload": {
                 "psr-0": {
-                    "Guzzle\\Http": ""
+                    "Guzzle": "src/",
+                    "Guzzle\\Tests": "tests/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -158,137 +149,45 @@
                     "name": "Michael Dowling",
                     "email": "mtdowling@gmail.com",
                     "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Guzzle Community",
+                    "homepage": "https://github.com/guzzle/guzzle/contributors"
                 }
             ],
-            "description": "HTTP libraries used by Guzzle",
+            "description": "PHP HTTP client. This library is deprecated in favor of https://packagist.org/packages/guzzlehttp/guzzle",
             "homepage": "http://guzzlephp.org/",
             "keywords": [
-                "Guzzle",
                 "client",
                 "curl",
+                "framework",
                 "http",
-                "http client"
+                "http client",
+                "rest",
+                "web service"
             ],
-            "abandoned": "guzzle/guzzle",
-            "time": "2013-12-04T22:21:25+00:00"
-        },
-        {
-            "name": "guzzle/parser",
-            "version": "v3.8.0",
-            "target-dir": "Guzzle/Parser",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Guzzle3/parser.git",
-                "reference": "77cae6425bc3466e1e47bdf6d2eebc15a092dbcc"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Guzzle3/parser/zipball/77cae6425bc3466e1e47bdf6d2eebc15a092dbcc",
-                "reference": "77cae6425bc3466e1e47bdf6d2eebc15a092dbcc",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.2"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.7-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Guzzle\\Parser": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Interchangeable parsers used by Guzzle",
-            "homepage": "http://guzzlephp.org/",
-            "keywords": [
-                "URI Template",
-                "cookie",
-                "http",
-                "message",
-                "url"
-            ],
-            "abandoned": "guzzle/guzzle",
-            "time": "2013-10-24T00:04:09+00:00"
-        },
-        {
-            "name": "guzzle/stream",
-            "version": "v3.8.0",
-            "target-dir": "Guzzle/Stream",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Guzzle3/stream.git",
-                "reference": "a86111d9ac7db31d65a053c825869409fe8fc83f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Guzzle3/stream/zipball/a86111d9ac7db31d65a053c825869409fe8fc83f",
-                "reference": "a86111d9ac7db31d65a053c825869409fe8fc83f",
-                "shasum": ""
-            },
-            "require": {
-                "guzzle/common": "self.version",
-                "php": ">=5.3.2"
-            },
-            "suggest": {
-                "guzzle/http": "To convert Guzzle request objects to PHP streams"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.7-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Guzzle\\Stream": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                }
-            ],
-            "description": "Guzzle stream wrapper component",
-            "homepage": "http://guzzlephp.org/",
-            "keywords": [
-                "Guzzle",
-                "component",
-                "stream"
-            ],
-            "abandoned": "guzzle/guzzle",
-            "time": "2013-07-30T22:07:23+00:00"
+            "abandoned": "guzzlehttp/guzzle",
+            "time": "2015-03-18T18:23:50+00:00"
         },
         {
             "name": "herrera-io/box",
-            "version": "1.5.1",
+            "version": "1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/box-project/box2-lib.git",
-                "reference": "596278d729b45ba2dab3f53897d62ac51e0db909"
+                "reference": "b55dceb5c65cc831e94ec0786b0b9b15f1103e8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/box-project/box2-lib/zipball/596278d729b45ba2dab3f53897d62ac51e0db909",
-                "reference": "596278d729b45ba2dab3f53897d62ac51e0db909",
+                "url": "https://api.github.com/repos/box-project/box2-lib/zipball/b55dceb5c65cc831e94ec0786b0b9b15f1103e8e",
+                "reference": "b55dceb5c65cc831e94ec0786b0b9b15f1103e8e",
                 "shasum": ""
             },
             "require": {
                 "ext-phar": "*",
                 "phine/path": "~1.0",
-                "php": ">=5.3.3"
+                "php": ">=5.3.3",
+                "tedivm/jshrink": "~1.0"
             },
             "require-dev": {
                 "herrera-io/annotations": "~1.0",
@@ -324,34 +223,34 @@
                 }
             ],
             "description": "A library for simplifying the PHAR build process.",
-            "homepage": "http://herrera-io.github.com/php-box",
+            "homepage": "https://github.com/box-project/box2-lib",
             "keywords": [
                 "phar"
             ],
-            "time": "2013-11-09T17:22:29+00:00"
+            "time": "2014-12-03T23:26:45+00:00"
         },
         {
             "name": "knplabs/packagist-api",
-            "version": "v1.1",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/KnpLabs/packagist-api.git",
-                "reference": "5d46003cfb1aca37efc84e8a0f1e8ba276a8245e"
+                "reference": "9aebf8238943289d3bc3ab51e0014ed94a7a266a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/KnpLabs/packagist-api/zipball/5d46003cfb1aca37efc84e8a0f1e8ba276a8245e",
-                "reference": "5d46003cfb1aca37efc84e8a0f1e8ba276a8245e",
+                "url": "https://api.github.com/repos/KnpLabs/packagist-api/zipball/9aebf8238943289d3bc3ab51e0014ed94a7a266a",
+                "reference": "9aebf8238943289d3bc3ab51e0014ed94a7a266a",
                 "shasum": ""
             },
             "require": {
                 "doctrine/inflector": "~1.0",
-                "guzzle/http": "~3.0",
+                "guzzle/guzzle": "~3.0",
                 "php": ">=5.3.2"
             },
             "require-dev": {
                 "phpspec/php-diff": "*@dev",
-                "phpspec/phpspec2": "1.0.*@dev"
+                "phpspec/phpspec": "~2.0"
             },
             "type": "library",
             "extra": {
@@ -381,7 +280,7 @@
                 "composer",
                 "packagist"
             ],
-            "time": "2013-11-22T09:55:31+00:00"
+            "time": "2015-09-07T14:25:16+00:00"
         },
         {
             "name": "phine/exception",
@@ -488,32 +387,37 @@
         },
         {
             "name": "symfony/console",
-            "version": "v2.4.1",
+            "version": "v2.6.13",
             "target-dir": "Symfony/Component/Console",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "4c1ed2ff514bd85ee186eebb010ccbdeeab05af7"
+                "reference": "0e5e18ae09d3f5c06367759be940e9ed3f568359"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/4c1ed2ff514bd85ee186eebb010ccbdeeab05af7",
-                "reference": "4c1ed2ff514bd85ee186eebb010ccbdeeab05af7",
+                "url": "https://api.github.com/repos/symfony/console/zipball/0e5e18ae09d3f5c06367759be940e9ed3f568359",
+                "reference": "0e5e18ae09d3f5c06367759be940e9ed3f568359",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
             "require-dev": {
-                "symfony/event-dispatcher": "~2.1"
+                "psr/log": "~1.0",
+                "symfony/event-dispatcher": "~2.1",
+                "symfony/phpunit-bridge": "~2.7",
+                "symfony/process": "~2.1"
             },
             "suggest": {
-                "symfony/event-dispatcher": ""
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/process": ""
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.4-dev"
+                    "dev-master": "2.6-dev"
                 }
             },
             "autoload": {
@@ -532,33 +436,38 @@
                 },
                 {
                     "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony Console Component",
-            "homepage": "http://symfony.com",
-            "time": "2014-01-01T08:14:50+00:00"
+            "homepage": "https://symfony.com",
+            "time": "2015-07-26T09:08:40+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v2.4.1",
+            "version": "v2.6.13",
             "target-dir": "Symfony/Component/EventDispatcher",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "e3ba42f6a70554ed05749e61b829550f6ac33601"
+                "reference": "672593bc4b0043a0acf91903bb75a1c82d8f2e02"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/e3ba42f6a70554ed05749e61b829550f6ac33601",
-                "reference": "e3ba42f6a70554ed05749e61b829550f6ac33601",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/672593bc4b0043a0acf91903bb75a1c82d8f2e02",
+                "reference": "672593bc4b0043a0acf91903bb75a1c82d8f2e02",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
             "require-dev": {
-                "symfony/dependency-injection": "~2.0"
+                "psr/log": "~1.0",
+                "symfony/config": "~2.0,>=2.0.5",
+                "symfony/dependency-injection": "~2.6",
+                "symfony/expression-language": "~2.6",
+                "symfony/phpunit-bridge": "~2.7",
+                "symfony/stopwatch": "~2.3"
             },
             "suggest": {
                 "symfony/dependency-injection": "",
@@ -567,7 +476,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.4-dev"
+                    "dev-master": "2.6-dev"
                 }
             },
             "autoload": {
@@ -586,35 +495,38 @@
                 },
                 {
                     "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony EventDispatcher Component",
-            "homepage": "http://symfony.com",
-            "time": "2013-12-28T08:12:03+00:00"
+            "homepage": "https://symfony.com",
+            "time": "2015-05-02T15:18:45+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v2.4.1",
+            "version": "v2.6.13",
             "target-dir": "Symfony/Component/Finder",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Finder.git",
-                "reference": "6904345cf2b3bbab1f6d6e4ce1724cb99df9f00a"
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "203a10f928ae30176deeba33512999233181dd28"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Finder/zipball/6904345cf2b3bbab1f6d6e4ce1724cb99df9f00a",
-                "reference": "6904345cf2b3bbab1f6d6e4ce1724cb99df9f00a",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/203a10f928ae30176deeba33512999233181dd28",
+                "reference": "203a10f928ae30176deeba33512999233181dd28",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
+            "require-dev": {
+                "symfony/phpunit-bridge": "~2.7"
+            },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.4-dev"
+                    "dev-master": "2.6-dev"
                 }
             },
             "autoload": {
@@ -633,35 +545,38 @@
                 },
                 {
                     "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony Finder Component",
-            "homepage": "http://symfony.com",
-            "time": "2014-01-01T08:14:50+00:00"
+            "homepage": "https://symfony.com",
+            "time": "2015-07-09T16:02:48+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v2.4.1",
+            "version": "v2.6.13",
             "target-dir": "Symfony/Component/Process",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Process.git",
-                "reference": "58fdccb311e44f28866f976c2d7b3227e9f713db"
+                "url": "https://github.com/symfony/process.git",
+                "reference": "57f1e88bb5dafa449b83f9f265b11d52d517b3e9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Process/zipball/58fdccb311e44f28866f976c2d7b3227e9f713db",
-                "reference": "58fdccb311e44f28866f976c2d7b3227e9f713db",
+                "url": "https://api.github.com/repos/symfony/process/zipball/57f1e88bb5dafa449b83f9f265b11d52d517b3e9",
+                "reference": "57f1e88bb5dafa449b83f9f265b11d52d517b3e9",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
+            "require-dev": {
+                "symfony/phpunit-bridge": "~2.7"
+            },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.4-dev"
+                    "dev-master": "2.6-dev"
                 }
             },
             "autoload": {
@@ -680,12 +595,58 @@
                 },
                 {
                     "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony Process Component",
-            "homepage": "http://symfony.com",
-            "time": "2014-01-05T02:10:50+00:00"
+            "homepage": "https://symfony.com",
+            "time": "2015-06-30T16:10:16+00:00"
+        },
+        {
+            "name": "tedivm/jshrink",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/tedious/JShrink.git",
+                "reference": "688527a2e854d7935f24f24c7d5eb1b604742bf9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/tedious/JShrink/zipball/688527a2e854d7935f24f24c7d5eb1b604742bf9",
+                "reference": "688527a2e854d7935f24f24c7d5eb1b604742bf9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "0.4.0",
+                "phpunit/phpunit": "4.0.*",
+                "satooshi/php-coveralls": "dev-master"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "JShrink": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Robert Hafner",
+                    "email": "tedivm@tedivm.com"
+                }
+            ],
+            "description": "Javascript Minifier built in PHP",
+            "homepage": "http://github.com/tedious/JShrink",
+            "keywords": [
+                "javascript",
+                "minifier"
+            ],
+            "time": "2015-07-04T07:35:09+00:00"
         }
     ],
     "packages-dev": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "65ee0740e960e2ec53863db29106857a",
+    "content-hash": "d1bb9730e0e624e9bf039c54cd8be9c8",
     "packages": [
         {
             "name": "doctrine/inflector",

--- a/src/Clue/PharComposer/App.php
+++ b/src/Clue/PharComposer/App.php
@@ -7,8 +7,6 @@ use Symfony\Component\Console\Input\InputInterface;
 
 class App extends BaseApplication
 {
-    private $isDefault = false;
-
     public function __construct()
     {
         parent::__construct('phar-composer', '@git_tag@');
@@ -16,37 +14,7 @@ class App extends BaseApplication
         $this->add(new Command\Build());
         $this->add(new Command\Search());
         $this->add(new Command\Install());
-    }
 
-    /**
-     * Gets the name of the command based on input.
-     *
-     * @param InputInterface $input The input interface
-     *
-     * @return string The command name
-     */
-    protected function getCommandName(InputInterface $input)
-    {
-        if ($input->getFirstArgument() === null && !$input->hasParameterOption(array('--help', '-h'))) {
-            $this->isDefault = true;
-            return 'search';
-        }
-        return parent::getCommandName($input);
-    }
-
-    /**
-     * Overridden so that the application doesn't expect the command
-     * name to be the first argument.
-     */
-    public function getDefinition()
-    {
-        $inputDefinition = parent::getDefinition();
-
-        if ($this->isDefault) {
-            // clear out the normal first argument, which is the command name
-            $inputDefinition->setArguments();
-        }
-
-        return $inputDefinition;
+        $this->setDefaultCommand('search');
     }
 }

--- a/src/Clue/PharComposer/Command/Build.php
+++ b/src/Clue/PharComposer/Command/Build.php
@@ -44,5 +44,7 @@ class Build extends Command
         }
 
         $pharer->build();
+
+        return 0;
     }
 }

--- a/src/Clue/PharComposer/Command/Install.php
+++ b/src/Clue/PharComposer/Command/Install.php
@@ -54,5 +54,7 @@ class Install extends Command
         }
 
         $this->packager->install($pharer, $path);
+
+        return 0;
     }
 }

--- a/src/Clue/PharComposer/Command/Install.php
+++ b/src/Clue/PharComposer/Command/Install.php
@@ -4,10 +4,11 @@ namespace Clue\PharComposer\Command;
 
 use Clue\PharComposer\Phar\Packager;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Helper\DialogHelper;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 class Install extends Command
 {
@@ -42,10 +43,11 @@ class Install extends Command
         $path = $this->packager->getSystemBin($pharer, $input->getArgument('target'));
 
         if (is_file($path)) {
-            $dialog = $this->getHelper('dialog');
-            assert($dialog instanceof DialogHelper);
+            $helper = $this->getHelper('question');
+            assert($helper instanceof QuestionHelper);
 
-            if (!$dialog->askConfirmation($output, 'Overwrite existing file <info>' . $path . '</info>? [y] > ')) {
+            $question = new ConfirmationQuestion('Overwrite existing file <info>' . $path . '</info>? [y] > ', true);
+            if (!$helper->ask($input, $output, $question)) {
                 $output->writeln('Aborting');
                 return 0;
             }

--- a/src/Clue/PharComposer/Command/Search.php
+++ b/src/Clue/PharComposer/Command/Search.php
@@ -158,5 +158,7 @@ class Search extends Command
         } else {
             $pharer->build();
         }
+
+        return 0;
     }
 }

--- a/src/Clue/PharComposer/Command/Search.php
+++ b/src/Clue/PharComposer/Command/Search.php
@@ -9,10 +9,12 @@ use Packagist\Api\Result\Package;
 use Packagist\Api\Result\Package\Version;
 use Packagist\Api\Result\Result;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Helper\DialogHelper;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+use Symfony\Component\Console\Question\Question;
 
 class Search extends Command
 {
@@ -44,30 +46,31 @@ class Search extends Command
     }
 
     /**
+     * @param InputInterface       $input
      * @param OutputInterface      $output
      * @param string               $label
      * @param array<string,string> $choices
      * @param ?string              $abortable
      * @return ?string
      */
-    protected function select(OutputInterface $output, $label, array $choices, $abortable = null)
+    protected function select(InputInterface $input, OutputInterface $output, $label, array $choices, $abortable = null)
     {
-        $dialog = $this->getHelper('dialog');
-        assert($dialog instanceof DialogHelper);
+        $helper = $this->getHelper('question');
+        assert($helper instanceof QuestionHelper);
 
         if (!$choices) {
             $output->writeln('<error>No matching packages found</error>');
             return null;
         }
 
-        // TODO: skip dialog, if exact match
-
+        // use numeric keys for all options
         $select = array_merge(array(0 => $abortable), array_values($choices));
         if ($abortable === null) {
             unset($select[0]);
         }
 
-        $index = $dialog->select($output, $label, $select);
+        $question = new ChoiceQuestion($label, $select);
+        $index = array_search($helper->ask($input, $output, $question), $select);
 
         if ($index === 0) {
             return null;
@@ -82,15 +85,16 @@ class Search extends Command
         $this->packager->setOutput($output);
         $this->packager->coerceWritable();
 
-        $dialog = $this->getHelper('dialog');
-        assert($dialog instanceof DialogHelper);
+        $helper = $this->getHelper('question');
+        assert($helper instanceof QuestionHelper);
 
         $project = $input->getArgument('project');
 
         do {
             if ($project === null) {
                 // ask for input
-                $project = $dialog->ask($output, 'Enter (partial) project name > ');
+                $question = new Question('Enter (partial) project name > ', '');
+                $project = $helper->ask($input, $output, $question);
             } else {
                 $output->writeln('Searching for <info>' . $project . '</info>...');
             }
@@ -108,7 +112,7 @@ class Search extends Command
                 $choices[$result->getName()] = $label;
             }
 
-            $project = $this->select($output, 'Select matching package', $choices, 'Start new search');
+            $project = $this->select($input, $output, 'Select matching package', $choices, 'Start new search');
         } while ($project === null);
 
         $output->writeln('Selected <info>' . $project . '</info>, listing versions...');
@@ -129,9 +133,10 @@ class Search extends Command
             $choices[$version->getVersion()] = $label;
         }
 
-        $version = $this->select($output, 'Select available version', $choices);
+        $version = $this->select($input, $output, 'Select available version', $choices);
 
         $action = $this->select(
+            $input,
             $output,
             'Action',
             array(

--- a/src/Clue/PharComposer/Phar/Packager.php
+++ b/src/Clue/PharComposer/Phar/Packager.php
@@ -250,7 +250,16 @@ class Packager
         //
         $output = $this->output;
 
-        $process = new Process($cmd, $chdir);
+        // Symfony 5+ requires 'fromShellCommandline', older versions support direct instantiation with command line
+        // @codeCoverageIgnoreStart
+        try {
+            new \ReflectionMethod('Symfony\Component\Process\Process', 'fromShellCommandline');
+            $process = Process::fromShellCommandline($cmd, $chdir);
+        } catch (\ReflectionException $e) {
+            $process = new Process($cmd, $chdir);
+        }
+        // @codeCoverageIgnoreEnd
+
         $process->setTimeout(null);
         $code = $process->run(function($type, $data) use ($output, &$nl) {
             if ($nl === true) {

--- a/src/Clue/PharComposer/Phar/Packager.php
+++ b/src/Clue/PharComposer/Phar/Packager.php
@@ -237,6 +237,12 @@ class Packager
         $this->log('    <info>OK</info> - ' . $success .' (after ' . round($time, 1) . 's)');
     }
 
+    /**
+     * @param string $cmd
+     * @param ?string $chdir
+     * @return void
+     * @throws UnexpectedValueException
+     */
     public function exec($cmd, $chdir = null)
     {
         $nl = true;

--- a/tests/Command/InstallTest.php
+++ b/tests/Command/InstallTest.php
@@ -58,6 +58,22 @@ class InstallTest extends TestCase
         $command->run($input, $output);
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function testNotBlockedByLegacyInstallation()
+    {
+        // Symfony 5+ added parameter type declarations, so we can use this to check which version is installed
+        $ref = new ReflectionMethod('Symfony\Component\Console\Command\Command', 'setName');
+        $params = $ref->getParameters();
+        if (PHP_VERSION_ID >= 70000 && isset($params[0]) && $params[0]->hasType()) {
+            $this->markTestSkipped('Unable to run this test (mocked QuestionHelper) with legacy PHPUnit against Symfony v5+');
+        }
+    }
+
+    /**
+     * @depends testNotBlockedByLegacyInstallation
+     */
     public function testExecuteInstallWillInstallPackagerWhenTargetPathAlreadyExistsAndDialogQuestionYieldsYes()
     {
         $input = $this->getMock('Symfony\Component\Console\Input\InputInterface');
@@ -87,6 +103,9 @@ class InstallTest extends TestCase
         $command->run($input, $output);
     }
 
+    /**
+     * @depends testNotBlockedByLegacyInstallation
+     */
     public function testExecuteInstallWillNotInstallPackagerWhenTargetPathAlreadyExistsAndDialogQuestionShouldNotOverwrite()
     {
         $input = $this->getMock('Symfony\Component\Console\Input\InputInterface');

--- a/tests/Command/InstallTest.php
+++ b/tests/Command/InstallTest.php
@@ -67,11 +67,11 @@ class InstallTest extends TestCase
         )->willReturnOnConsecutiveCalls('dir', null);
         $output = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
 
-        $dialogHelper = $this->getMock('Symfony\Component\Console\Helper\DialogHelper');
-        $dialogHelper->expects($this->once())->method('askConfirmation')->willReturn(true);
+        $questionHelper = $this->getMock('Symfony\Component\Console\Helper\QuestionHelper');
+        $questionHelper->expects($this->once())->method('ask')->willReturn(true);
 
         $helpers = new HelperSet(array(
-            'dialog' => $dialogHelper
+            'question' => $questionHelper
         ));
 
         $pharer = $this->getMockBuilder('Clue\PharComposer\Phar\PharComposer')->disableOriginalConstructor()->getMock();
@@ -97,11 +97,11 @@ class InstallTest extends TestCase
         $output = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
         $output->expects($this->once())->method('writeln')->with('Aborting');
 
-        $dialogHelper = $this->getMock('Symfony\Component\Console\Helper\DialogHelper');
-        $dialogHelper->expects($this->once())->method('askConfirmation')->willReturn(false);
+        $questionHelper = $this->getMock('Symfony\Component\Console\Helper\QuestionHelper');
+        $questionHelper->expects($this->once())->method('ask')->willReturn(false);
 
         $helpers = new HelperSet(array(
-            'dialog' => $dialogHelper
+            'question' => $questionHelper
         ));
 
         $pharer = $this->getMockBuilder('Clue\PharComposer\Phar\PharComposer')->disableOriginalConstructor()->getMock();

--- a/tests/Command/SearchTest.php
+++ b/tests/Command/SearchTest.php
@@ -22,8 +22,22 @@ class SearchTest extends TestCase
     }
 
     /**
+     * @doesNotPerformAssertions
+     */
+    public function testNotBlockedByLegacyInstallation()
+    {
+        // Symfony 5+ added parameter type declarations, so we can use this to check which version is installed
+        $ref = new ReflectionMethod('Symfony\Component\Console\Command\Command', 'setName');
+        $params = $ref->getParameters();
+        if (PHP_VERSION_ID >= 70000 && isset($params[0]) && $params[0]->hasType()) {
+            $this->markTestSkipped('Unable to run this test (mocked QuestionHelper) with legacy PHPUnit against Symfony v5+');
+        }
+    }
+
+    /**
      * @expectedException RuntimeException
      * @expectedExceptionMessage stop1
+     * @depends testNotBlockedByLegacyInstallation
      */
     public function testExecuteWithoutProjectWillAskForProjectAndRunSearch()
     {
@@ -51,6 +65,7 @@ class SearchTest extends TestCase
     /**
      * @expectedException RuntimeException
      * @expectedExceptionMessage stop1
+     * @depends testNotBlockedByLegacyInstallation
      */
     public function testExecuteWithProjectWillRunSearchWithoutAskingForProject()
     {
@@ -78,6 +93,7 @@ class SearchTest extends TestCase
     /**
      * @expectedException RuntimeException
      * @expectedExceptionMessage stop1
+     * @depends testNotBlockedByLegacyInstallation
      */
     public function testExecuteWithProjectAndSearchReturnsNoMatchesWillReportAndAskForOtherProject()
     {
@@ -109,6 +125,7 @@ class SearchTest extends TestCase
     /**
      * @expectedException RuntimeException
      * @expectedExceptionMessage stop1
+     * @depends testNotBlockedByLegacyInstallation
      */
     public function testExecuteWithProjectAndSearchReturnsOneMatchWillAskForProject()
     {
@@ -138,6 +155,7 @@ class SearchTest extends TestCase
     /**
      * @expectedException RuntimeException
      * @expectedExceptionMessage stop1
+     * @depends testNotBlockedByLegacyInstallation
      */
     public function testExecuteWithProjectSelectedWillSearchVersions()
     {
@@ -172,6 +190,9 @@ class SearchTest extends TestCase
         $command->run($input, $output);
     }
 
+    /**
+     * @depends testNotBlockedByLegacyInstallation
+     */
     public function testExecuteWithProjectAndVersionSelectedWillQuitWhenAskedForActionYieldsQuit()
     {
         $input = $this->getMock('Symfony\Component\Console\Input\InputInterface');
@@ -209,6 +230,9 @@ class SearchTest extends TestCase
         $command->run($input, $output);
     }
 
+    /**
+     * @depends testNotBlockedByLegacyInstallation
+     */
     public function testExecuteWithProjectAndVersionSelectedWillBuildWhenAskedForActionYieldsBuild()
     {
         $input = $this->getMock('Symfony\Component\Console\Input\InputInterface');
@@ -250,6 +274,9 @@ class SearchTest extends TestCase
         $command->run($input, $output);
     }
 
+    /**
+     * @depends testNotBlockedByLegacyInstallation
+     */
     public function testExecuteWithProjectAndVersionSelectedWillInstallWhenAskedForActionYieldsInstall()
     {
         $input = $this->getMock('Symfony\Component\Console\Input\InputInterface');

--- a/tests/Command/SearchTest.php
+++ b/tests/Command/SearchTest.php
@@ -31,11 +31,11 @@ class SearchTest extends TestCase
         $input->expects($this->once())->method('getArgument')->with('project')->willReturn(null);
         $output = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
 
-        $dialogHelper = $this->getMock('Symfony\Component\Console\Helper\DialogHelper');
-        $dialogHelper->expects($this->once())->method('ask')->willReturn('foo');
+        $questionHelper = $this->getMock('Symfony\Component\Console\Helper\QuestionHelper');
+        $questionHelper->expects($this->once())->method('ask')->willReturn('foo');
 
         $helpers = new HelperSet(array(
-            'dialog' => $dialogHelper
+            'question' => $questionHelper
         ));
 
         $packager = $this->getMock('Clue\PharComposer\Phar\Packager');
@@ -58,11 +58,11 @@ class SearchTest extends TestCase
         $input->expects($this->once())->method('getArgument')->with('project')->willReturn('foo');
         $output = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
 
-        $dialogHelper = $this->getMock('Symfony\Component\Console\Helper\DialogHelper');
-        $dialogHelper->expects($this->never())->method('ask');
+        $questionHelper = $this->getMock('Symfony\Component\Console\Helper\QuestionHelper');
+        $questionHelper->expects($this->never())->method('ask');
 
         $helpers = new HelperSet(array(
-            'dialog' => $dialogHelper
+            'question' => $questionHelper
         ));
 
         $packager = $this->getMock('Clue\PharComposer\Phar\Packager');
@@ -89,11 +89,11 @@ class SearchTest extends TestCase
             array('<error>No matching packages found</error>')
         );
 
-        $dialogHelper = $this->getMock('Symfony\Component\Console\Helper\DialogHelper');
-        $dialogHelper->expects($this->once())->method('ask')->willThrowException(new RuntimeException('stop1'));
+        $questionHelper = $this->getMock('Symfony\Component\Console\Helper\QuestionHelper');
+        $questionHelper->expects($this->once())->method('ask')->willThrowException(new RuntimeException('stop1'));
 
         $helpers = new HelperSet(array(
-            'dialog' => $dialogHelper
+            'question' => $questionHelper
         ));
 
         $packager = $this->getMock('Clue\PharComposer\Phar\Packager');
@@ -116,12 +116,11 @@ class SearchTest extends TestCase
         $input->expects($this->once())->method('getArgument')->with('project')->willReturn('foo');
         $output = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
 
-        $dialogHelper = $this->getMock('Symfony\Component\Console\Helper\DialogHelper');
-        $dialogHelper->expects($this->once())->method('select')->willThrowException(new RuntimeException('stop1'));
-        $dialogHelper->expects($this->never())->method('ask');
+        $questionHelper = $this->getMock('Symfony\Component\Console\Helper\QuestionHelper');
+        $questionHelper->expects($this->once())->method('ask')->willThrowException(new RuntimeException('stop1'));
 
         $helpers = new HelperSet(array(
-            'dialog' => $dialogHelper
+            'question' => $questionHelper
         ));
 
         $packager = $this->getMock('Clue\PharComposer\Phar\Packager');
@@ -150,12 +149,13 @@ class SearchTest extends TestCase
             array('Selected <info>foo/bar</info>, listing versions...')
         );
 
-        $dialogHelper = $this->getMock('Symfony\Component\Console\Helper\DialogHelper');
-        $dialogHelper->expects($this->once())->method('select')->willReturn(1);
-        $dialogHelper->expects($this->never())->method('ask');
+        $questionHelper = $this->getMock('Symfony\Component\Console\Helper\QuestionHelper');
+        $questionHelper->expects($this->once())->method('ask')->willReturn(
+            '<info>foo</info>/bar                                  (⤓)'
+        );
 
         $helpers = new HelperSet(array(
-            'dialog' => $dialogHelper
+            'question' => $questionHelper
         ));
 
         $packager = $this->getMock('Clue\PharComposer\Phar\Packager');
@@ -178,12 +178,15 @@ class SearchTest extends TestCase
         $input->expects($this->once())->method('getArgument')->with('project')->willReturn('foo');
         $output = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
 
-
-        $dialogHelper = $this->getMock('Symfony\Component\Console\Helper\DialogHelper');
-        $dialogHelper->expects($this->exactly(3))->method('select')->willReturnOnConsecutiveCalls(1, 1, 0);
+        $questionHelper = $this->getMock('Symfony\Component\Console\Helper\QuestionHelper');
+        $questionHelper->expects($this->exactly(3))->method('ask')->willReturnOnConsecutiveCalls(
+            '<info>foo</info>/bar                                  (⤓)',
+            'dev-master (<error>no executable bin</error>)',
+            'Quit'
+        );
 
         $helpers = new HelperSet(array(
-            'dialog' => $dialogHelper
+            'question' => $questionHelper
         ));
 
         $packager = $this->getMock('Clue\PharComposer\Phar\Packager');
@@ -212,11 +215,15 @@ class SearchTest extends TestCase
         $input->expects($this->once())->method('getArgument')->with('project')->willReturn('foo');
         $output = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
 
-        $dialogHelper = $this->getMock('Symfony\Component\Console\Helper\DialogHelper');
-        $dialogHelper->expects($this->exactly(3))->method('select')->willReturnOnConsecutiveCalls(1, 1, 1);
+        $questionHelper = $this->getMock('Symfony\Component\Console\Helper\QuestionHelper');
+        $questionHelper->expects($this->exactly(3))->method('ask')->willReturnOnConsecutiveCalls(
+            '<info>foo</info>/bar                                  (⤓)',
+            'dev-master (<error>no executable bin</error>)',
+            'Build project'
+        );
 
         $helpers = new HelperSet(array(
-            'dialog' => $dialogHelper
+            'question' => $questionHelper
         ));
 
         $pharer = $this->getMockBuilder('Clue\PharComposer\Phar\PharComposer')->disableOriginalConstructor()->getMock();
@@ -249,11 +256,15 @@ class SearchTest extends TestCase
         $input->expects($this->once())->method('getArgument')->with('project')->willReturn('foo');
         $output = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
 
-        $dialogHelper = $this->getMock('Symfony\Component\Console\Helper\DialogHelper');
-        $dialogHelper->expects($this->exactly(3))->method('select')->willReturnOnConsecutiveCalls(1, 1, 2);
+        $questionHelper = $this->getMock('Symfony\Component\Console\Helper\QuestionHelper');
+        $questionHelper->expects($this->exactly(3))->method('ask')->willReturnOnConsecutiveCalls(
+            '<info>foo</info>/bar                                  (⤓)',
+            'dev-master (<error>no executable bin</error>)',
+            'Install project system-wide'
+        );
 
         $helpers = new HelperSet(array(
-            'dialog' => $dialogHelper
+            'question' => $questionHelper
         ));
 
         $pharer = $this->getMockBuilder('Clue\PharComposer\Phar\PharComposer')->disableOriginalConstructor()->getMock();

--- a/tests/install-as-dep/composer.json
+++ b/tests/install-as-dep/composer.json
@@ -1,0 +1,14 @@
+{
+    "require": {
+        "symfony/console": "^4.0"
+    },
+    "require-dev": {
+        "clue/phar-composer": "*@dev"
+    },
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../../"
+        }
+    ]
+}


### PR DESCRIPTION
This changeset includes a simple test to verify installation of this
project as dependency works alongside symfony/console:^4.0.

Symfony 5 has yet to be released (ETA this month), but some manual tests
against the current development version suggest this is supported as
well.

Supersedes / closes #73 
Supersedes / closes #74
Supersedes / closes #82
Builds on top of https://github.com/clue/graph-composer/pull/48 and #86