### PR TITLE
Significantly improve performance when adding phar contents

### DIFF
--- a/src/Clue/PharComposer/Phar/PharComposer.php
+++ b/src/Clue/PharComposer/Phar/PharComposer.php
@@ -158,7 +158,7 @@ class PharComposer
             }
         }
 
-        $targetPhar = TargetPhar::create($target, $this);
+        $targetPhar = new TargetPhar(new \Phar($target), $this);
         $this->log('  - Adding main package "' . $this->package->getName() . '"');
         $targetPhar->addBundle($this->package->getBundler($this->logger)->bundle());
 
@@ -175,7 +175,6 @@ class PharComposer
             $this->log('  - Adding dependency "' . $package->getName() . '" from "' . $this->getPathLocalToBase($package->getDirectory()) . '"');
             $targetPhar->addBundle($package->getBundler($this->logger)->bundle());
         }
-
 
         $this->log('  - Setting main/stub');
         $chmod = 0755;
@@ -204,7 +203,7 @@ class PharComposer
             $this->log('    Using referenced chmod ' . sprintf('%04o', $chmod));
         }
 
-        $targetPhar->finalize();
+        $targetPhar->stopBuffering();
 
         if ($chmod !== null) {
             $this->log('    Applying chmod ' . sprintf('%04o', $chmod));
@@ -214,8 +213,6 @@ class PharComposer
         }
 
         $time = max(microtime(true) - $time, 0);
-
-
 
         $this->log('');
         $this->log('    <info>OK</info> - Creating <info>' . $this->getTarget() .'</info> (' . $this->getSize($this->getTarget()) . ') completed after ' . round($time, 1) . 's');

--- a/src/Clue/PharComposer/Phar/TargetPhar.php
+++ b/src/Clue/PharComposer/Phar/TargetPhar.php
@@ -2,59 +2,32 @@
 
 namespace Clue\PharComposer\Phar;
 
-use Herrera\Box\Box;
-use Traversable;
 use Clue\PharComposer\Package\Bundle;
 
 /**
  * Represents the target phar to be created.
- *
- * TODO: replace PharComposer with a new BasePath class
  */
 class TargetPhar
 {
-    /**
-     *
-     * @type  PharComposer
-     */
+    /** @var \Phar */
+    private $phar;
+
+    /** @var  PharComposer */
     private $pharComposer;
-    /**
-     *
-     * @type  Box
-     */
-    private $box;
 
-    /**
-     * constructor
-     *
-     * @param  Box           $box
-     * @param  PharComposer  $pharComposer
-     */
-    public function __construct(Box $box, PharComposer $pharComposer)
+    public function __construct(\Phar $phar, PharComposer $pharComposer)
     {
-        $this->box = $box;
-        $this->box->getPhar()->startBuffering();
+        $phar->startBuffering();
+        $this->phar = $phar;
         $this->pharComposer = $pharComposer;
-    }
-
-    /**
-     * create new instance in target path
-     *
-     * @param   string        $target
-     * @param   PharComposer  $pharComposer
-     * @return  TargetPhar
-     */
-    public static function create($target, PharComposer $pharComposer)
-    {
-        return new self(Box::create($target), $pharComposer);
     }
 
     /**
      * finalize writing of phar file
      */
-    public function finalize()
+    public function stopBuffering()
     {
-        $this->box->getPhar()->stopBuffering();
+        $this->phar->stopBuffering();
     }
 
     /**
@@ -74,25 +47,18 @@ class TargetPhar
     }
 
      /**
-     * Adds a file to the Phar, after compacting it and replacing its
-     * placeholders.
+     * Adds a file to the Phar
      *
      * @param string $file  The file name.
      */
     public function addFile($file)
     {
-        $this->box->addFile($file, $this->pharComposer->getPathLocalToBase($file));
+        $this->phar->addFile($file, $this->pharComposer->getPathLocalToBase($file));
     }
 
-     /**
-     * Similar to Phar::buildFromIterator(), except the files will be compacted
-     * and their placeholders replaced.
-     *
-     * @param Traversable $iterator The iterator.
-     */
-    public function buildFromIterator(Traversable $iterator)
+    public function buildFromIterator(\Traversable $iterator)
     {
-        $this->box->buildFromIterator($iterator, $this->pharComposer->getPackageRoot()->getDirectory());
+        $this->phar->buildFromIterator($iterator, $this->pharComposer->getPackageRoot()->getDirectory());
     }
 
     /**
@@ -102,11 +68,11 @@ class TargetPhar
      */
     public function setStub($stub)
     {
-        $this->box->getPhar()->setStub($stub);
+        $this->phar->setStub($stub);
     }
 
     public function addFromString($local, $contents)
     {
-        $this->box->addFromString($local, $contents);
+        $this->phar->addFromString($local, $contents);
     }
 }

--- a/tests/Phar/TargetPharTest.php
+++ b/tests/Phar/TargetPharTest.php
@@ -15,8 +15,6 @@ class TargetPharTest extends TestCase
 
     private $mockPhar;
 
-    private $mockBox;
-
     private $mockPharComposer;
 
     /**
@@ -29,12 +27,8 @@ class TargetPharTest extends TestCase
         }
 
         $this->mockPhar = $this->createMock('\Phar');
-        $this->mockBox  = $this->createMock('Herrera\Box\Box');
-        $this->mockBox->expects($this->any())
-                      ->method('getPhar')
-                      ->will($this->returnValue($this->mockPhar));
         $this->mockPharComposer = $this->createMock('Clue\PharComposer\Phar\PharComposer');
-        $this->targetPhar       = new TargetPhar($this->mockBox, $this->mockPharComposer);
+        $this->targetPhar       = new TargetPhar($this->mockPhar, $this->mockPharComposer);
     }
 
     private function createMock($class)
@@ -53,7 +47,7 @@ class TargetPharTest extends TestCase
                                ->method('getPathLocalToBase')
                                ->with($this->equalTo('path/to/package/file.php'))
                                ->will($this->returnValue('file.php'));
-        $this->mockBox->expects($this->once())
+        $this->mockPhar->expects($this->once())
                       ->method('addFile')
                       ->with($this->equalTo('path/to/package/file.php'), $this->equalTo('file.php'));
         $this->targetPhar->addFile('path/to/package/file.php');
@@ -69,7 +63,7 @@ class TargetPharTest extends TestCase
         $this->mockPharComposer->expects($this->once())
                                ->method('getPackageRoot')
                                ->willReturn($mockPackage);
-        $this->mockBox->expects($this->once())
+        $this->mockPhar->expects($this->once())
                       ->method('buildFromIterator')
                       ->with($this->equalTo($mockTraversable), $this->equalTo('path/to/package/'));
         $this->targetPhar->buildFromIterator($mockTraversable);
@@ -86,7 +80,7 @@ class TargetPharTest extends TestCase
                                ->method('getPathLocalToBase')
                                ->with($this->equalTo('path/to/package/file.php'))
                                ->will($this->returnValue('file.php'));
-        $this->mockBox->expects($this->once())
+        $this->mockPhar->expects($this->once())
                       ->method('addFile')
                       ->with($this->equalTo('path/to/package/file.php'), $this->equalTo('file.php'));
         $mockFinder = $this->createMock('Symfony\Component\Finder\Finder');
@@ -95,7 +89,7 @@ class TargetPharTest extends TestCase
         $this->mockPharComposer->expects($this->once())
                                ->method('getPackageRoot')
                                ->willReturn($mockPackage);
-        $this->mockBox->expects($this->once())
+        $this->mockPhar->expects($this->once())
                       ->method('buildFromIterator')
                       ->with($this->equalTo($mockFinder), $this->equalTo('path/to/package/'));
         $this->targetPhar->addBundle($bundle);
@@ -115,10 +109,21 @@ class TargetPharTest extends TestCase
     /**
      * @test
      */
-    public function finalizeStopsBufferingOnUnderlyingPhar()
+    public function stopBufferingStopsBufferingOnUnderlyingPhar()
     {
         $this->mockPhar->expects($this->once())
                        ->method('stopBuffering');
-        $this->targetPhar->finalize();
+        $this->targetPhar->stopBuffering();
+    }
+
+    /**
+     * @test
+     */
+    public function addFromStringOnUnderlyingPhar()
+    {
+        $this->mockPhar->expects($this->once())
+                       ->method('addFromString')
+                       ->with('path/file', 'contents');
+        $this->targetPhar->addFromString('path/file', 'contents');
     }
 }


### PR DESCRIPTION
Skip unneeded indirection through Box and add files directly to
underlying Phar instance. This speeds up build times considerably, e.g.
building this project changed from ~37s to ~1s on my laptop.