### PR TITLE
Add build script removing uneeded files and update development docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /vendor
+/build
+/phar-composer-*.phar

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ matrix:
     - php: 7.3
       install: []
       script: composer install --dry-run --working-dir=tests/install-as-dep
+    - php: 7.3
+      script: composer build
   allow_failures:
     - php: hhvm
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ for your project among with its bundled dependencies.
     * [Updating phar](#updating-phar)
   * [Installation using Composer](#installation-using-composer)
     * [Updating dependency](#updating-dependency)
-  * [Manual Installation from Source](#manual-installation-from-source)
-    * [Updating manually](#updating-manually)
+* [Development](#development)
 * [Tests](#tests)
 * [License](#license)
 
@@ -208,38 +207,72 @@ source code as a library is *not supported*.
 
 Just run `composer update clue/phar-composer` to update to the latest release.
 
-### Manual Installation from Source
+## Development
 
-This project requires PHP 5.3+ and Composer:
+clue/phar-composer is an [open-source project](#license) and encourages everybody to
+participate in its development.
+You're interested in checking out how clue/phar-composer works under the hood and/or want
+to contribute to the development of clue/phar-composer?
+Then this section is for you!
+
+The recommended way to install clue/phar-composer is to clone (or download) this repository
+and use [Composer](http://getcomposer.org) to download its dependencies.
+Therefore you'll need PHP, Composer, git and curl installed.
+For example, on a recent Ubuntu/Debian-based system, simply run:
 
 ```bash
+$ sudo apt install php-cli git curl
+
 $ git clone https://github.com/clue/phar-composer.git
 $ cd phar-composer
+
 $ curl -s https://getcomposer.org/installer | php
-$ php composer.phar install
+$ sudo mv composer.phar /usr/local/bin/composer
+
+$ composer install
 ```
 
-You can now verify everything works by running phar-composer like this:
+You can now verify everything works by running clue/phar-composer like this:
 
 ```bash
 $ php bin/phar-composer --version
 ```
 
-Optionally, you can now build the above mentioned `phar-composer.phar` yourself by issuing:
+If you want to distribute clue/phar-composer as a single standalone release file, you may
+compile the project into a single `phar-composer.phar` file like this:
 
 ```bash
-$ composer install --no-dev
-$ php bin/phar-composer build
+$ composer build
 ```
 
-Optionally, you can now follow the above instructions for a [system-wide installation](#as-a-phar-recommended).
+> Note that compiling will temporarily install a copy of this project to the
+  local `build/` directory and install all non-development dependencies
+  for distribution. This should only take a second or two if you've previously
+  installed its dependencies already.
+  The build script optionally accepts the version number (`VERSION` env) and
+  an output file name or will otherwise try to look up the last release tag,
+  such as `phar-composer-1.0.0.phar`.
 
-#### Updating manually
+You can now verify the resulting `phar-composer.phar` file works by running it
+like this:
+
+```bash
+$ ./phar-composer.phar --version
+```
+
+To update your development version to the latest version, just run this:
 
 ```bash
 $ git pull
 $ php composer.phar install
 ```
+
+Made some changes to your local development version?
+
+Make sure to let the world know! :shipit:
+We welcome PRs and would love to hear from you!
+
+Happy hacking!
 
 ## Tests
 

--- a/bin/build.php
+++ b/bin/build.php
@@ -1,0 +1,30 @@
+<?php
+
+// explicitly give VERSION via ENV or ask git for current version
+$version = getenv('VERSION');
+if ($version === false) {
+    $version = ltrim(exec('git describe --always --dirty', $_, $code), 'v');
+    if ($code !== 0) {
+        fwrite(STDERR, 'Error: Unable to get version info from git. Try passing VERSION via ENV' . PHP_EOL);
+        exit(1);
+    }
+}
+
+// use first argument as output file or use "phar-composer-{version}.phar"
+$out = isset($argv[1]) ? $argv[1] : ('phar-composer-' . $version . '.phar');
+
+passthru('
+rm -rf build && mkdir build &&
+cp -r bin/ src/ composer.json composer.lock LICENSE build/ && rm build/bin/build.php &&
+sed -i \'s/@git_tag@/' . $version .'/g\' build/src/Clue/PharComposer/App.php &&
+composer install -d build/ --no-dev &&
+
+cd build/vendor && rm -rf */*/tests/ */*/src/tests/ */*/docs/ */*/*.md */*/composer.* */*/phpunit.* */*/.gitignore */*/.*.yml */*/*.xml && cd - >/dev/null &&
+cd build/vendor/symfony/ && rm -rf */Symfony/Component/*/Tests/ */Symfony/Component/*/*.md */Symfony/Component/*/composer.* */Symfony/Component/*/phpunit.* */Symfony/Component/*/.gitignore && cd ->/dev/null &&
+cd build/vendor/guzzle/guzzle && rm -r phar-stub.php phing/ && cd ->/dev/null &&
+cd build/vendor/herrera-io/box && rm -r res && cd ->/dev/null &&
+cd build/vendor/phine/path && rm sami.php .travis-phpunit.xml && cd ->/dev/null &&
+bin/phar-composer build build/ ' . escapeshellarg($out) . ' &&
+
+echo -n "Reported version is: " && php ' . escapeshellarg($out) . ' --version', $code);
+exit($code);

--- a/composer.json
+++ b/composer.json
@@ -33,5 +33,8 @@
         "platform": {
             "php": "5.3.6"
         }
+    },
+    "scripts": {
+        "build": "@php bin/build.php"
     }
 }


### PR DESCRIPTION
This now includes a `composer build` script to build the `phar-composer.phar` release phar file. This will automatically patch the application version from git source info.

Resolves / closes #39
Heavily inspired by https://github.com/clue/graph-composer/pull/44 and https://github.com/leproxy/leproxy/pull/33