### PR TITLE
Composer v2 compatibility

### DIFF
--- a/src/Clue/PharComposer/Phar/PharComposer.php
+++ b/src/Clue/PharComposer/Phar/PharComposer.php
@@ -126,6 +126,9 @@ class PharComposer
             // file does not exist if there's nothing to be installed
             $installed = $this->loadJson($pathVendor . 'composer/installed.json');
 
+            // composer 2 compatibility packages come in a subindex named packages
+            $installed = is_array($installed['packages']) ? $installed['packages'] : $installed;
+            
             foreach ($installed as $package) {
                 $dir = $package['name'] . '/';
                 if (isset($package['target-dir'])) {

--- a/src/Clue/PharComposer/Phar/PharComposer.php
+++ b/src/Clue/PharComposer/Phar/PharComposer.php
@@ -126,8 +126,8 @@ class PharComposer
             // file does not exist if there's nothing to be installed
             $installed = $this->loadJson($pathVendor . 'composer/installed.json');
 
-            // composer 2 compatibility packages come in a subindex named packages
-            $installed = is_array($installed['packages']) ? $installed['packages'] : $installed;
+            // composer 2 compatibility packages come in a index named packages
+            $installed = empty($installed['packages']) ? $installed : $installed['packages'];
             
             foreach ($installed as $package) {
                 $dir = $package['name'] . '/';


### PR DESCRIPTION
Resolution of #106 and #105 

As on composer 2 **installed.json** comes with an new index [**packages**] instead of root

This code would not iterate between packages
```php
foreach ($installed as $package) {
```

by adding this line before would make this composer 2 compatible and keep backward also:
```php
$installed = is_array($installed['packages']) ? $installed['packages'] : $installed;
```

