### PR TITLE
Composer path with spaces bugfix

### DIFF
--- a/src/Phar/Packager.php
+++ b/src/Phar/Packager.php
@@ -132,6 +132,10 @@ class Packager
             $finder = new ExecutableFinder();
 
             $git = $finder->find('git', '/usr/bin/git');
+            
+            if (preg_match('/\s/', $git)) {
+                $git = '"' . $git . '"';
+            }
 
             $that = $this;
             $this->displayMeasure(
@@ -154,6 +158,11 @@ class Packager
             } else {
                 $command = $finder->find('composer', '/usr/bin/composer');
             }
+            
+            if (preg_match('/\s/', $command)) {
+                $command = '"' . $command . '"';
+            }
+            
             $command .= ' install --no-dev --no-progress --no-scripts';
 
             $this->displayMeasure(
@@ -182,11 +191,12 @@ class Packager
                 $command = $finder->find('php', '/usr/bin/php') . ' composer.phar';
             } else {
                 $command = $finder->find('composer', '/usr/bin/composer');
-                
-                if (preg_match('/\s/', $command)) {
-                    $command = '"' . $command . '"';
-                }
             }
+            
+            if (preg_match('/\s/', $command)) {
+                $command = '"' . $command . '"';
+            }
+            
             $command .= ' create-project ' . escapeshellarg($package) . ' ' . escapeshellarg($path) . ' --no-dev --no-progress --no-scripts';
 
             $that = $this;

--- a/src/Phar/Packager.php
+++ b/src/Phar/Packager.php
@@ -182,6 +182,10 @@ class Packager
                 $command = $finder->find('php', '/usr/bin/php') . ' composer.phar';
             } else {
                 $command = $finder->find('composer', '/usr/bin/composer');
+                
+                if (preg_match('/\s/', $command)) {
+                    $command = '"' . $command . '"';
+                }
             }
             $command .= ' create-project ' . escapeshellarg($package) . ' ' . escapeshellarg($path) . ' --no-dev --no-progress --no-scripts';
 


### PR DESCRIPTION
Probably it works on linux environment, but on windows, if composer's executable file located by path that includes the spaces, command can't be executed. So this small fix should will prevent this error.