### PR TITLE
Drop legacy HHVM support due to lack of support and failing test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,15 +43,3 @@ jobs:
       - run: composer require symfony/console:^3.0 --dry-run --working-dir=tests/install-as-dep
         if: ${{ matrix.php >= 5.5 && matrix.php < 8.0 }}
       - run: composer install --dry-run --working-dir=tests/install-as-dep
-
-  PHPUnit-hhvm:
-    name: PHPUnit (HHVM)
-    runs-on: ubuntu-18.04
-    steps:
-      - uses: actions/checkout@v2
-      - uses: azjezz/setup-hhvm@v1
-        with:
-          version: lts-3.30
-      - run: hhvm $(which composer) install
-      - run: hhvm vendor/bin/phpunit
-      - run: composer install --dry-run --working-dir=tests/install-as-dep

--- a/README.md
+++ b/README.md
@@ -141,8 +141,7 @@ its version and will then offer you to either `build` or `install` it.
 You can grab a copy of clue/phar-composer in either of the following ways.
 
 This project aims to run on any platform and thus does not require any PHP
-extensions and supports running on legacy PHP 5.3 through current PHP 8+ and
-HHVM.
+extensions and supports running on legacy PHP 5.3 through current PHP 8+.
 It's *highly recommended to use the latest supported PHP version* for this project.
 
 ### As a phar (recommended)


### PR DESCRIPTION
HHVM does not support PHP anymore and regularly causes our builds to fail, so no reason to keep legacy HHVM support around anymore.

Builds on top of #112, #85, #58 and others
