### PR TITLE
[FEATURE] Add symfony v7 support

### DIFF
--- a/bin/build.php
+++ b/bin/build.php
@@ -17,12 +17,11 @@ passthru('
 rm -rf build && mkdir build &&
 cp -r bin/ src/ composer.json LICENSE build/ && rm build/bin/build.php build/src/Box/Extract.php &&
 sed -i \'s/@dev/' . $version .'/g\' build/src/App.php &&
-composer config -d build/ platform.php 5.3.6 &&
+composer config -d build/ platform.php 7.0.33 &&
 composer install -d build/ --no-dev &&
 
 cd build/vendor && rm -rf */*/tests/ */*/src/tests/ */*/docs/ */*/*.md */*/composer.* */*/phpunit.* */*/.gitignore */*/.*.yml */*/*.xml && cd - >/dev/null &&
 cd build/vendor/symfony/ && rm -rf */Symfony/Component/*/Tests/ */Symfony/Component/*/*.md */Symfony/Component/*/composer.* */Symfony/Component/*/phpunit.* */Symfony/Component/*/.gitignore && cd ->/dev/null &&
-cd build/vendor/guzzle/guzzle && rm -r phar-stub.php phing/ && cd ->/dev/null &&
 build/bin/phar-composer build build/ ' . escapeshellarg($out) . ' &&
 
 echo -n "Reported version is: " && php ' . escapeshellarg($out) . ' --version', $code);

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.6",
+        "php": ">=7.0.33",
         "knplabs/packagist-api": "^1.0",
         "symfony/console": "^6.0 || ^5.0 || ^4.0 || ^3.0 || ^2.5",
         "symfony/finder": "^6.0 || ^5.0 || ^4.0 || ^3.0 || ^2.5",

--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,9 @@
     "require": {
         "php": ">=7.0.33",
         "knplabs/packagist-api": "^1.0",
-        "symfony/console": "^6.0 || ^5.0 || ^4.0 || ^3.0 || ^2.5",
-        "symfony/finder": "^6.0 || ^5.0 || ^4.0 || ^3.0 || ^2.5",
-        "symfony/process": "^6.0 || ^5.0 || ^4.0 || ^3.0 || ^2.5"
+        "symfony/console": "^7.0 || ^6.0 || ^5.0 || ^4.0 || ^3.0",
+        "symfony/finder": "^7.0 || ^6.0 || ^5.0 || ^4.0 || ^3.0",
+        "symfony/process": "^7.0 || ^6.0 || ^5.0 || ^4.0 || ^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5 || ^5.7 || ^4.8.36"

--- a/src/Command/Build.php
+++ b/src/Command/Build.php
@@ -31,7 +31,7 @@ class Build extends Command
              ->addArgument('target', InputArgument::OPTIONAL, 'Path to write phar output to (defaults to project name)');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->packager->setOutput($output);
         $this->packager->coerceWritable();

--- a/src/Command/Install.php
+++ b/src/Command/Install.php
@@ -40,7 +40,7 @@ class Install extends Command
              ->addArgument('target', InputArgument::OPTIONAL, 'Path to install to', '/usr/local/bin');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if ($this->isWindows) {
             $output->writeln('<error>Command not available on this platform. Please use the "build" command and place Phar in your $PATH manually.</error>');

--- a/src/Command/Search.php
+++ b/src/Command/Search.php
@@ -87,7 +87,7 @@ class Search extends Command
         return $indices[$index - 1];
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->packager->setOutput($output);
         $this->packager->coerceWritable();


### PR DESCRIPTION
To make this package compatible with symfony 7, the symfony commands needed to be adjusted. This makes the package incompatible with PHP5.3. This PR sets the minimum required PHP version to 7.0.