### PR TITLE
Test on PHP 8.3 and update test environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,10 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-22.04
+          - ubuntu-24.04
           - windows-2022
         php:
+          - 8.3
           - 8.2
           - 8.1
           - 8.0


### PR DESCRIPTION
This PR only updates to PHP 8.3 so far, because upgrading to PHP 8.4 needs avoiding implicitly nullable types first.
Will try to solve this in another PR.
Builds on top #131.